### PR TITLE
Add Spanish translation.

### DIFF
--- a/languages/es.js
+++ b/languages/es.js
@@ -1,0 +1,117 @@
+const COMMAND = require('linguacode-constants').COMMAND;
+
+module.exports = [{
+  command: COMMAND.INPUT,
+  definition: 'entrada'
+}, {
+  command: COMMAND.OUTPUT,
+  definition: 'salida'
+}, {
+  command: COMMAND.IF,
+  definition: 'si'
+}, {
+  command: COMMAND.ELSE,
+  definition: 'acaso'
+}, {
+  command: COMMAND.THEN,
+  definition: 'entonces'
+}, {
+  command: COMMAND.OR,
+  definition: 'o'
+}, {
+  command: COMMAND.AND,
+  definition: 'y'
+}, {
+  command: COMMAND.NOT,
+  definition: 'no'
+}, {
+  command: COMMAND.FALSE,
+  definition: 'falso'
+}, {
+  command: COMMAND.TRUE,
+  definition: 'verdadero'
+}, {
+  command: COMMAND.DO,
+  definition: 'hacer'
+}, {
+  command: COMMAND.WHILE,
+  definition: 'mientras'
+}, {
+  command: COMMAND.REPEAT,
+  definition: 'repetir'
+}, {
+  command: COMMAND.TIMES,
+  definition: 'veces'
+}, {
+  command: COMMAND.BREAK,
+  definition: 'abortar'
+}, {
+  command: COMMAND.CONTINUE,
+  definition: 'continuar'
+}, {
+  command: COMMAND.FUNCTION,
+  definition: 'función'
+}, {
+  command: COMMAND.RANDOM,
+  definition: 'aleatorio'
+}, {
+  command: COMMAND.POW,
+  definition: 'potencia'
+}, {
+  command: COMMAND.SQR,
+  definition: 'cuadrado'
+}, {
+  command: COMMAND.SQRT,
+  definition: 'raíz'
+}, {
+  command: COMMAND.ROUND,
+  definition: 'redondear'
+}, {
+  command: COMMAND.FLOOR,
+  definition: 'suelo'
+}, {
+  command: COMMAND.CEIL,
+  definition: 'techo'
+}, {
+  command: COMMAND.ABS,
+  definition: 'abs'
+}, {
+  command: COMMAND.SIN,
+  definition: 'sen'
+}, {
+  command: COMMAND.COS,
+  definition: 'cos'
+}, {
+  command: COMMAND.TAN,
+  definition: 'tan'
+}, {
+  command: COMMAND.CTG,
+  definition: 'cot'
+}, {
+  command: COMMAND.ARCSIN,
+  definition: 'arcosen'
+}, {
+  command: COMMAND.ARCCOS,
+  definition: 'arcocos'
+}, {
+  command: COMMAND.ARCTAN,
+  definition: 'arcotan'
+}, {
+  command: COMMAND.ARCCTG,
+  definition: 'arcocot'
+}, {
+  command: COMMAND.LOG,
+  definition: 'log'
+}, {
+  command: COMMAND.LN,
+  definition: 'ln'
+}, {
+  command: COMMAND.LG,
+  definition: 'lg'
+}, {
+  command: COMMAND.PI,
+  definition: 'pi'
+}, {
+  command: COMMAND.E,
+  definition: 'e'
+}];


### PR DESCRIPTION
Hi,
This is a translation for european Spanish (Spain). 

Small changes may be needed for a latin-american Spanish version. Mostly: "cierto" instead of "verdadero" (true) and keep "random" instead of "aleatorio". 

However, most latin americans think of european Spanish as a "robotic" version of the Spanish language, so that feeling makes this translation very suitable for coding, IMHO. 

Regards